### PR TITLE
Delete unnecessary `.npmrc`

### DIFF
--- a/resolve-component-library/.npmrc
+++ b/resolve-component-library/.npmrc
@@ -1,2 +1,0 @@
-//npm.pkg.github.com/:_authToken=${GH_DEPS_PAT}
-@shape-construction:registry=https://npm.pkg.github.com


### PR DESCRIPTION
`.npmrc` file was kept in the library folder although we already removed any reference to private packages. This led to some errors during interviews. 